### PR TITLE
Make compatible with non-bash shells, etc— portability changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A linux bash script collection which downloads nopaystation PS Vita stuff.
 There are four Scripts. One to download all \*.tsv files of NoPayStation. The other three are for downloading games, updates or all DLC of a PS Vita game.
 
 ## Requirements
-* bash
-* curl
+* posix shell (bash, ksh, zsh, sh)
+* curl or wget
 * [*pkg2zip*](https://github.com/mmozeiko/pkg2zip)
 * latest [*mktorrent*](https://github.com/Rudde/mktorrent)
 

--- a/download2torrent.sh
+++ b/download2torrent.sh
@@ -18,10 +18,10 @@ my_usage(){
 }
 
 # check if necessary binaries are available
-MY_BINARIES=("curl" "pkg2zip" "mktorrent" "sed")
-for bins in ${MY_BINARIES[@]}
+MY_BINARIES="pkg2zip mktorrent sed"
+for bins in $MY_BINARIES
 do
-    if [ ! -x $(which ${bins}) ]
+    if [ ! -x $(which "${bins}") ]
     then
         echo "$bins isn't installed."
         echo "Please install it and try again"
@@ -60,7 +60,7 @@ then
 fi
 
 ### check if nps tsv file directory exists
-if [ ! -d ${NPS_DIR} ]
+if [ ! -d "${NPS_DIR}" ]
 then
     echo "Directory containing *.tsv files missing (\"${NPS_DIR}\"). Check your path parameter."
     my_usage
@@ -68,16 +68,17 @@ then
 fi
 
 ### check if the tsv files are available to call download scripts
-for tsv_file in PSV_GAMES.tsv PSV_DLCS.tsv PSV_UPDATES.tsv;
+tsv_files="PSV_GAMES.tsv PSV_DLCS.tsv PSV_UPDATES.tsv"
+for tsv_file in $tsv_files
 do
-    if [ ! -f ${NPS_DIR}/${tsv_file} ]
+    if [ ! -f "${NPS_DIR}/${tsv_file}" ]
     then
         echo "*.tsv file \"${tsv_file}\" in path \"${NPS_DIR}\" missing."
         exit 1
     fi
 done
 
-echo ${ANNOUNCE_URL} | grep "^http" &> /dev/null
+echo "${ANNOUNCE_URL}" | grep "^http" &> /dev/null
 if [ $? -ne 0 ]
 then
     echo "No valid announce url provided. Be sure that the url starts with \"http\" and has a correct hostname"
@@ -85,7 +86,7 @@ then
 fi
 
 ### Download the chosen game
-download_game.sh ${NPS_DIR}/PSV_GAMES.tsv ${MEDIA_ID}
+download_game.sh "${NPS_DIR}/PSV_GAMES.tsv" "${MEDIA_ID}"
 if [ $? -ne 0 ]
 then
     echo ""
@@ -94,14 +95,14 @@ then
 fi
 
 ### Get name of the zip file from generated txt created via download_game.sh
-ZIP_FILENAME=$(cat ${MEDIA_ID}.txt)
-GAME_NAME=$(echo ${ZIP_FILENAME} | sed 's/.zip//g')
+ZIP_FILENAME="$(cat ${MEDIA_ID}.txt)"
+GAME_NAME="$(echo "${ZIP_FILENAME}" | sed 's/.zip//g')"
 
 ### Download available updates
-DESTDIR="${GAME_NAME}" download_update.sh ${NPS_DIR}/PSV_UPDATES.tsv ${MEDIA_ID}
+DESTDIR="${GAME_NAME}" download_update.sh "${NPS_DIR}/PSV_UPDATES.tsv" "${MEDIA_ID}"
 
 ### Download available DLC
-DESTDIR="${GAME_NAME}" download_dlc.sh ${NPS_DIR}/PSV_DLCS.tsv ${MEDIA_ID}
+DESTDIR="${GAME_NAME}" download_dlc.sh "${NPS_DIR}/PSV_DLCS.tsv" "${MEDIA_ID}"
 
 ### Creating the torrent files
 echo "Creating torrent file for \"${GAME_NAME}.zip\""
@@ -133,7 +134,7 @@ then
 fi
 
 ### remove temporary game name file
-rm ${MEDIA_ID}.txt
+rm "${MEDIA_ID}.txt"
 
 ### Run post scripts
 if [ -x ./download2torrent_post.sh ]

--- a/download_dlc.sh
+++ b/download_dlc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # AUTHOR sigmaboy <j.sigmaboy@gmail.com>
 # Version 0.1
@@ -9,10 +9,57 @@ my_usage(){
     echo "$0 \"/path/to/DLC.tsv\" \"PCSE00986\""
 }
 
-MY_BINARIES=("curl" "pkg2zip" "sed" "sha256sum")
-for bins in ${MY_BINARIES[@]}
+function my_sha256 {
+    local file="$1"
+
+    case "$SHA256" in
+        "sha256sum")
+            sha256sum "$file" | awk '{ print $1 }' ;;
+        "sha256")
+            sha256    "$file" | awk '{ print $4 }' ;;
+    esac
+}
+
+function sha256_choose {
+    if whereis sha256 > /dev/null 2>&1
+    then
+        MY_BINARIES="${MY_BINARIES} sha256"
+        SHA256="sha256"
+    else
+        MY_BINARIES="${MY_BINARIES} sha256sum"
+        SHA256="sha256sum"
+    fi
+}
+
+function my_download_file {
+    local url="$1"
+    local destination="$2"
+
+    case "$DOWNLOADER" in
+        "wget")
+            wget -O "$destination" "$url" ;;
+        "curl")
+            curl -o "$destination" "$url" ;;
+    esac
+}
+
+function downloader_choose {
+    if whereis wget > /dev/null 2>&1
+    then
+        MY_BINARIES="${MY_BINARIES} wget"
+        DOWNLOADER="wget"
+    else
+        MY_BINARIES="${MY_BINARIES} curl"
+        DOWNLOADER="curl"
+    fi
+}
+
+MY_BINARIES="pkg2zip sed"
+sha256_choose; downloader_choose
+
+for bins in $MY_BINARIES
 do
-    if ! which ${bins} > /dev/null 2>&1
+    if ! which "${bins}" > /dev/null 2>&1
     then
         echo "$bins isn't installed."
         echo "Please install it and try again"
@@ -37,8 +84,14 @@ then
     exit 1
 fi
 
-LIST=$(grep "^${GAME_ID}" ${TSV_FILE} | cut -f"4,5,9" | sed 's/\t/,/g' | sed 's/\r//g')
-MY_PATH=$(pwd)
+LIST="$(grep "^${GAME_ID}" ${TSV_FILE}  | sed 's%.*http%http%' | tr '\n' "|" \
+        | tr '\r' "%" | sed 's^%^^g')"
+# both '\n' and '\r' are removed, since the TSV file is usually DOS-style
+# '\r' bytes interfere with string comparison later on, so we remove them
+# '\n' is replaced with a "|" character, since that's what awk will use as
+# delimeter
+
+MY_PATH="$(pwd)"
 
 # make DESTDIR overridable
 if [ -z "$DESTDIR" ]
@@ -46,11 +99,18 @@ then
     DESTDIR="${GAME_ID}"
 fi
 
-for i in $LIST;
+i=1
+max="$(echo "$(echo "$LIST" | grep -o "|" | wc -l) + 1" | bc)"
+
+while [ "$i" -ne "$max" ]
 do
-    LINK=$(echo $i | cut -d"," -f1)
-    KEY=$(echo $i | cut -d"," -f2)
-    LIST_SHA256=$(echo $i | xargs | cut -d"," -f3)
+    local item="$(echo "$LIST" | awk -F "|" "{ print \$$i }")"
+    i="$(echo "$i + 1" | bc)"
+
+    LINK="$(echo "$item" | awk '{ print $1 }')"
+    KEY="$(echo "$item"  | awk '{ print $2 }')"
+    LIST_SHA256="$(echo "$item" | awk '{ print $7 }')"
+
     if [ $KEY = "MISSING" ] || [ $LINK = "MISSING" ]
     then
         echo "zrif key or download link missing."
@@ -60,11 +120,16 @@ do
             mkdir "${MY_PATH}/${DESTDIR}_dlc"
         fi
         cd "${MY_PATH}/${DESTDIR}_dlc"
-        wget -O ${GAME_ID}_dlc.pkg -c "$LINK"
-        FILE_SHA256=$(sha256sum ${GAME_ID}_dlc.pkg | xargs | cut -d" " -f"1")
-        if [ ${FILE_SHA256} != ${LIST_SHA256} ]
+	my_download_file "$LINK" "${GAME_ID}_dlc.pkg"
+        FILE_SHA256="$(my_sha256 "${GAME_ID}_dlc.pkg")"
+
+        if [ "${FILE_SHA256}" != "${LIST_SHA256}" ]
         then
             echo "Checksum of downloaded file does not match checksum in list"
+
+	    echo "${FILE_SHA256}" > /tmp/a
+	    echo "${LIST_SHA256}" > /tmp/b
+
             LOOP=1
             while [ $LOOP -eq 1 ]
             do
@@ -83,8 +148,8 @@ do
                 fi
             done
         fi
-        pkg2zip ${GAME_ID}_dlc.pkg "$KEY"
-        rm ${GAME_ID}_dlc.pkg
-        cd ${MY_PATH}
+        pkg2zip "${GAME_ID}_dlc.pkg" "$KEY"
+        rm "${GAME_ID}_dlc.pkg"
+        cd "${MY_PATH}"
     fi
 done

--- a/download_tsv.sh
+++ b/download_tsv.sh
@@ -1,12 +1,39 @@
-#!/bin/bash
-HEADER="https://";
-BASE_URL="nopaystation.com";
-MY_URL_PATH="tsv";
-LIST=("PSV_GAMES" "PSV_DLCS" "PSM_GAMES" "PSV_UPDATES" "PSV_THEMES" "PSX_GAMES" "PSP_GAMES" "PSP_DLCS" "PSP_THEMES" "PS3_GAMES" "PS3_DLCS" "PS3_THEMES" "PS3_AVATARS" "PS4_GAMES" "PS4_DLCS" "PS4_UPDATES" "PS4_THEMES");
-MY_NAME="NoPayStation";
+#!/bin/sh
+HEADER="https://"
+BASE_URL="nopaystation.com"
+MY_URL_PATH="tsv"
+LIST="PSV_GAMES PSV_DLCS PSM_GAMES PSV_UPDATES PSV_THEMES PSX_GAMES PSP_GAMES"
+LIST="${LIST} PSP_DLCS PSP_THEMES PS3_GAMES PS3_DLCS PS3_THEMES PS3_AVATARS"
+LIST="${LIST} PS4_GAMES PS4_DLCS PS4_UPDATES PS4_THEMES"
+MY_NAME="NoPayStation"
 
-MY_BINARIES=("curl")
-for bins in ${MY_BINARIES[@]}
+function my_download_file {
+    local url="$1"
+    local destination="$2"
+
+    case "$DOWNLOADER" in
+        "wget")
+            wget -O "$destination" "$url" ;;
+        "curl")
+            curl -o "$destination" "$url" ;;
+    esac
+}
+
+function downloader_choose {
+    if whereis wget > /dev/null 2>&1
+    then
+        MY_BINARIES="${MY_BINARIES} wget"
+        DOWNLOADER="wget"
+    else
+        MY_BINARIES="${MY_BINARIES} curl"
+        DOWNLOADER="curl"
+    fi
+}
+
+MY_BINARIES=""
+downloader_choose
+
+for bins in $MY_BINARIES
 do
     if ! which ${bins} > /dev/null 2>&1
     then
@@ -16,30 +43,32 @@ do
     fi
 done
 
-if [ -z ${1} ];
+if [ -z "${1}" ]
 then
-    DEST=$(pwd);
+    DEST="$(pwd)"
 else
-    DEST=${1};
+    DEST="${1}"
 fi
-MY_DATE=$(date "+%d_%m_%Y");
-if [ -f ${DEST}/${MY_NAME}_${MY_DATE}.tar.gz ];
+MY_DATE="$(date "+%d_%m_%Y")"
+if [ -f "${DEST}/${MY_NAME}_${MY_DATE}.tar.gz" ]
 then
-    echo "Backup of the current day already exists. Skipping";
-    exit 1;
-fi;
+    echo "Backup of the current day already exists. Skipping"
+    exit 1
+fi
 
-if [ ! -d ${DEST}/${MY_DATE} ];
+if [ ! -d "${DEST}/${MY_DATE}" ]
 then
-    mkdir ${DEST}/${MY_DATE};
-fi;
+    mkdir "${DEST}/${MY_DATE}"
+fi
 
-for i in ${LIST[@]};
+for i in $LIST
 do
-    wget -O ${DEST}/${MY_DATE}/${i}.tsv -c "${HEADER}${BASE_URL}/${MY_URL_PATH}/${i}.tsv";
-done;
+    my_download_file "${HEADER}${BASE_URL}/${MY_URL_PATH}/${i}.tsv" \
+                     "${DEST}/${MY_DATE}/${i}.tsv"
+done
 
-wget -O ${DEST}/${MY_DATE}/feed.html -c ${HEADER}${BASE_URL}/feed/english.html;
-tar -C ${DEST} -czf ${DEST}/${MY_NAME}_${MY_DATE}.tar.gz ${MY_DATE};
+my_download_file "${HEADER}${BASE_URL}/feed/english.html" \
+                 "${DEST}/${MY_DATE}/feed.html"
+tar -C "${DEST}" -czf "${DEST}/${MY_NAME}_${MY_DATE}.tar.gz" "${MY_DATE}"
 
-rm -r ${DEST}/${MY_DATE};
+rm -r "${DEST}/${MY_DATE}"

--- a/download_update.sh
+++ b/download_update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # AUTHOR sigmaboy <j.sigmaboy@gmail.com>
 # Version 0.1
@@ -9,10 +9,57 @@ my_usage(){
     echo "$0 \"/path/to/DLC.tsv\" \"PCSE00986\""
 }
 
-MY_BINARIES=("curl" "pkg2zip" "sed" "sha256sum")
-for bins in ${MY_BINARIES[@]}
+function my_sha256 {
+    local file="$1"
+
+    case "$SHA256" in
+        "sha256sum")
+            sha256sum "$file" | awk '{ print $1 }' ;;
+        "sha256")
+            sha256    "$file" | awk '{ print $4 }' ;;
+    esac
+}
+
+function sha256_choose {
+    if whereis sha256 > /dev/null 2>&1
+    then
+        MY_BINARIES="${MY_BINARIES} sha256"
+        SHA256="sha256"
+    else
+        MY_BINARIES="${MY_BINARIES} sha256sum"
+        SHA256="sha256sum"
+    fi
+}
+
+function my_download_file {
+    local url="$1"
+    local destination="$2"
+
+    case "$DOWNLOADER" in
+        "wget")
+            wget -O "$destination" "$url" ;;
+        "curl")
+            curl -o "$destination" "$url" ;;
+    esac
+}
+
+function downloader_choose {
+    if whereis wget > /dev/null 2>&1
+    then
+        MY_BINARIES="${MY_BINARIES} wget"
+        DOWNLOADER="wget"
+    else
+        MY_BINARIES="${MY_BINARIES} curl"
+        DOWNLOADER="curl"
+    fi
+}
+
+
+MY_BINARIES="pkg2zip sed"
+sha256_choose; downloader_choose
+for bins in $MY_BINARIES
 do
-    if ! which ${bins} > /dev/null 2>&1
+    if ! which "${bins}" > /dev/null 2>&1
     then
         echo "$bins isn't installed."
         echo "Please install it and try again"
@@ -37,8 +84,16 @@ then
     exit 1
 fi
 
-LIST=$(grep "^${GAME_ID}" "${TSV_FILE}" | cut -f"6,9" | sed 's/\t/,/g' | sed 's/\r//g')
-MY_PATH=$(pwd)
+LIST="$(grep "^${GAME_ID}" "${TSV_FILE}" | sed 's/.*http/http/' | tr '\n' "|" \
+        | tr '\r' "%" | sed 's^%^^g')"
+
+if [ -z "$LIST" ]
+then
+	echo "No updates for this game!"
+	exit 2
+fi
+
+MY_PATH="$(pwd)"
 
 # make DESTDIR overridable
 if [ -z "$DESTDIR" ]
@@ -46,18 +101,25 @@ then
     DESTDIR="${GAME_ID}"
 fi
 
-for i in $LIST;
+i=1
+max="$(echo "$(echo "$LIST" | grep -o "|" | wc -l) + 1" | bc)"
+
+while [ "$i" -ne "$max" ]
 do
-    LINK=$(echo $i | cut -d"," -f1)
-    LIST_SHA256=$(echo $i | xargs | cut -d"," -f2)
+    local item="$(echo "$LIST" | awk -F "|" "{ print \$$i }")"
+    i="$(echo "$i + 1" | bc)"
+    echo "$item"
+
+    LINK="$(echo "$item" | awk '{ print $1 }')"
+    LIST_SHA256="$(echo "$item" | awk '{ print $5 }')"
     if [ ! -d "${MY_PATH}/${DESTDIR}_update" ]
     then
         mkdir "${MY_PATH}/${DESTDIR}_update"
     fi
     cd "${MY_PATH}/${DESTDIR}_update"
-    wget -O ${GAME_ID}_update.pkg -c "$LINK"
-    FILE_SHA256=$(sha256sum ${GAME_ID}_update.pkg | xargs | cut -d" " -f"1")
-    if [ ${FILE_SHA256} != ${LIST_SHA256} ]
+    my_download_file "$LINK" "${GAME_ID}_update.pkg"
+    FILE_SHA256="$(my_sha256 "${GAME_ID}_update.pkg")"
+    if [ "${FILE_SHA256}" != "${LIST_SHA256}" ]
     then
         echo "Checksum of downloaded file does not match checksum in list"
         LOOP=1
@@ -73,12 +135,12 @@ do
                 LOOP=0
                 echo "User aborted."
                 echo "Downloaded file removed."
-                rm ${GAME_ID}_update.pkg
+                rm "${GAME_ID}_update.pkg"
                 exit 1
             fi
         done
     fi
-    pkg2zip ${GAME_ID}_update.pkg
-    rm ${GAME_ID}_update.pkg
-    cd ${MY_PATH}
+    pkg2zip "${GAME_ID}_update.pkg"
+    rm "${GAME_ID}_update.pkg"
+    cd "${MY_PATH}"
 done


### PR DESCRIPTION
These are just a few changes that make it so the script can run on basically any system— curl _or_ wget used can be used, sha256 _or_ sha256sum can be used, and all arrays are replaced with simple strings. 

(Arrays are a bashism that can be useful sometimes, but aren't usually necessary. Here, since every item in the arrays were only one word long, iterating through the string works perfectly, since space is the default delimeter.)